### PR TITLE
testnode_start.sh: change 'os_version' to '9.stream'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 RUN dnf -y update && \
     rpm --setcaps shadow-utils 2>/dev/null && \
     dnf -y install podman crun --exclude container-selinux && \
@@ -32,7 +32,6 @@ RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/
 ENV _CONTAINERS_USERNS_CONFIGURED=""
 
 RUN dnf -y install \
-    /usr/bin/lsb_release \
     which \
     sudo \
     openssh-clients \

--- a/testnode_start.sh
+++ b/testnode_start.sh
@@ -3,7 +3,7 @@ set -x
 cat /run/secrets/id_rsa.pub >> /root/.ssh/authorized_keys
 cat /run/secrets/id_rsa.pub >> /home/ubuntu/.ssh/authorized_keys
 chown ubuntu /home/ubuntu/.ssh/authorized_keys
-payload="{\"name\": \"$(hostname)\", \"machine_type\": \"testnode\", \"up\": true, \"locked\": false, \"os_type\": \"centos\", \"os_version\": \"8.stream\"}"
+payload="{\"name\": \"$(hostname)\", \"machine_type\": \"testnode\", \"up\": true, \"locked\": false, \"os_type\": \"centos\", \"os_version\": \"9.stream\"}"
 for i in $(seq 1 5); do
     echo "attempt $i"
     curl -v -f -d "$payload" http://paddles:8080/nodes/ && break


### PR DESCRIPTION
Now that we use centos9 as base image
for teuthology-testnode, paddles should
also store 'os_version' as '9.stream' for
these nodes.